### PR TITLE
Add ability to scan barcode to AddItemPage

### DIFF
--- a/InventorySystem/InventorySystem/InventorySystem/InventorySystem.csproj
+++ b/InventorySystem/InventorySystem/InventorySystem/InventorySystem.csproj
@@ -21,6 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="Views\AddBarcodeScannerPage.xaml.cs">
+      <DependentUpon>AddBarcodeScannerPage.xaml</DependentUpon>
+    </Compile>
     <Compile Update="Views\MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>

--- a/InventorySystem/InventorySystem/InventorySystem/Views/AddBarcodeScannerPage.xaml
+++ b/InventorySystem/InventorySystem/InventorySystem/Views/AddBarcodeScannerPage.xaml
@@ -3,17 +3,18 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:forms="clr-namespace:ZXing.Net.Mobile.Forms;assembly=ZXing.Net.Mobile.Forms"
-             x:Class="InventorySystem.Views.CustomScannerPage">
+             x:Class="InventorySystem.Views.AddBarcodeScannerPage">
     <ContentPage.Content>
         <Grid>
             <forms:ZXingScannerView x:Name="zxing"
                                     HorizontalOptions="FillAndExpand"
                                     VerticalOptions="FillAndExpand"
-                                    OnScanResult="Zxing_OnOnScanResult" />
+                                    OnScanResult="Zxing_OnScanResult" />
             <forms:ZXingDefaultOverlay x:Name="overlay"
                                        TopText="Wyrównaj kod kreskowy z linią w ramce"
                                        BottomText="Skanowanie nastąpi automatycznie"
-                                       FlashButtonClicked="Overlay_OnFlashButtonClicked" />
+                                       FlashButtonClicked="Overlay_OnFlashButtonClicked"
+                                       ShowFlashButton="True"/>
         </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/InventorySystem/InventorySystem/InventorySystem/Views/AddBarcodeScannerPage.xaml.cs
+++ b/InventorySystem/InventorySystem/InventorySystem/Views/AddBarcodeScannerPage.xaml.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using InventorySystem.Models;
+using InventorySystem.Services;
+using InventorySystem.ViewModels;
+using Xamarin.Essentials;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+using ZXing;
+using ZXing.Mobile;
+
+namespace InventorySystem.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class AddBarcodeScannerPage : ContentPage
+    {
+        public AddBarcodeScannerPage()
+        {
+            InitializeComponent();
+
+            zxing.AutomationId = "zxingScannerView";
+            overlay.AutomationId = "zxingDefaultOverlay";
+
+            zxing.Options = new MobileBarcodeScanningOptions
+            {
+                DelayBetweenContinuousScans = 2000,
+                AutoRotate = true,
+                UseFrontCameraIfAvailable = false,
+                PossibleFormats = new List<BarcodeFormat>
+                {
+                    BarcodeFormat.EAN_8, BarcodeFormat.EAN_13, BarcodeFormat.UPC_A
+                }
+            };
+
+            overlay.ShowFlashButton = zxing.HasTorch;
+        }
+
+        private void Overlay_OnFlashButtonClicked(Button sender, EventArgs e)
+        {
+            zxing.IsTorchOn = !zxing.IsTorchOn;
+        }
+
+        private void Zxing_OnScanResult(Result result)
+        {
+            //Stop scanning
+            zxing.IsAnalyzing = false;
+
+            Preferences.Set("ScannedBarcode", result.Text);
+
+            Device.BeginInvokeOnMainThread(async () =>
+            {
+                await Shell.Current.Navigation.PopAsync();
+            });
+        }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+
+            zxing.IsScanning = true;
+        }
+
+        protected override void OnDisappearing()
+        {
+            zxing.IsScanning = false;
+
+            base.OnDisappearing();
+        }
+    }
+}

--- a/InventorySystem/InventorySystem/InventorySystem/Views/AddItemPage.xaml
+++ b/InventorySystem/InventorySystem/InventorySystem/Views/AddItemPage.xaml
@@ -57,25 +57,39 @@
                 <Label Text="Kod kreskowy:"
                    FontSize="Title"
                    HorizontalOptions="StartAndExpand" />
-                <Entry x:Name="BarcodeEntry"
-                   Keyboard="Numeric"
-                   Placeholder="Ciąg cyfr"
-                   Text="{Binding Barcode, Mode=TwoWay}"
-                   FontAttributes="Bold"
-                   IsSpellCheckEnabled="False"
-                   TextChanged="BarcodeEntry_OnTextChanged">
 
-                    <Entry.Behaviors>
+                <Grid Padding="0,10,0, 10"
+                      ColumnDefinitions="Auto">
+                    
+                    <Entry Grid.Column="0"
+                           Grid.ColumnSpan="5"
+                           HorizontalOptions="FillAndExpand"
+                           x:Name="BarcodeEntry"
+                           Keyboard="Numeric"
+                           Placeholder="Ciąg cyfr"
+                           Text="{Binding Barcode, Mode=TwoWay}"
+                           FontAttributes="Bold"
+                           IsSpellCheckEnabled="False"
+                           TextChanged="BarcodeEntry_OnTextChanged">
+                        <Entry.Behaviors>
 
-                        <xct:CharactersValidationBehavior x:Name="CharacterQuantityValidator"
+                            <xct:CharactersValidationBehavior x:Name="CharacterQuantityValidator"
                                                       CharacterType="Digit"
                                                       MinimumCharacterCount="8"
                                                       MaximumCharacterCount="14"
                                                       InvalidStyle="{StaticResource InvalidBackgroundEntry}" />
 
-                    </Entry.Behaviors>
+                        </Entry.Behaviors>
+                    </Entry>
 
-                </Entry>
+                    <ImageButton Grid.Column="5"
+                                 HorizontalOptions="Center"
+                                 Source="scanner_button50x50.png"
+                                 BackgroundColor="Transparent"
+                                 WidthRequest="50"
+                                 HeightRequest="50"
+                                 Command="{Binding GetBarcodeCommand}" />
+                </Grid>
 
                 <Label x:Name="BarcodeNotValidLabel" Text="Podany kod kreskowy jest niepoprawny."
                    IsVisible="False"

--- a/InventorySystem/InventorySystem/InventorySystem/Views/SearchForScannerPage.xaml
+++ b/InventorySystem/InventorySystem/InventorySystem/Views/SearchForScannerPage.xaml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:forms="clr-namespace:ZXing.Net.Mobile.Forms;assembly=ZXing.Net.Mobile.Forms"
+             x:Class="InventorySystem.Views.SearchForScannerPage">
+    <ContentPage.Content>
+        <Grid>
+            <forms:ZXingScannerView x:Name="zxing"
+                                    HorizontalOptions="FillAndExpand"
+                                    VerticalOptions="FillAndExpand"
+                                    OnScanResult="Zxing_OnScanResult" />
+            <forms:ZXingDefaultOverlay x:Name="overlay"
+                                       TopText="Wyrównaj kod kreskowy z linią w ramce"
+                                       BottomText="Skanowanie nastąpi automatycznie"
+                                       FlashButtonClicked="Overlay_OnFlashButtonClicked"
+                                       ShowFlashButton="True"/>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/InventorySystem/InventorySystem/InventorySystem/Views/SearchForScannerPage.xaml.cs
+++ b/InventorySystem/InventorySystem/InventorySystem/Views/SearchForScannerPage.xaml.cs
@@ -10,11 +10,11 @@ using ZXing.Mobile;
 namespace InventorySystem.Views
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
-    public partial class CustomScannerPage : ContentPage
+    public partial class SearchForScannerPage : ContentPage
     {
         private static readonly RestService RestClient = new RestService();
 
-        public CustomScannerPage()
+        public SearchForScannerPage()
         {
             InitializeComponent();
 
@@ -24,9 +24,8 @@ namespace InventorySystem.Views
             zxing.Options = new MobileBarcodeScanningOptions
             {
                 DelayBetweenContinuousScans = 2000,
-                AutoRotate = false,
+                AutoRotate = true,
                 UseFrontCameraIfAvailable = false,
-                TryHarder = true,
                 PossibleFormats = new List<BarcodeFormat>
                 {
                     BarcodeFormat.EAN_8, BarcodeFormat.EAN_13, BarcodeFormat.UPC_A
@@ -41,7 +40,7 @@ namespace InventorySystem.Views
             zxing.IsTorchOn = !zxing.IsTorchOn;
         }
 
-        private void Zxing_OnOnScanResult(Result result)
+        private void Zxing_OnScanResult(Result result)
         {
             //Stop scanning
             zxing.IsAnalyzing = false;

--- a/InventorySystem/InventorySystem/InventorySystem/obj/Debug/netstandard2.0/InventorySystem.csproj.FileListAbsolute.txt
+++ b/InventorySystem/InventorySystem/InventorySystem/obj/Debug/netstandard2.0/InventorySystem.csproj.FileListAbsolute.txt
@@ -52,3 +52,5 @@ C:\Users\chudy\Documents\InventorySystem_App\InventorySystem\InventorySystem\Inv
 C:\Users\chudy\Documents\InventorySystem_App\InventorySystem\InventorySystem\InventorySystem\obj\Debug\netstandard2.0\InventorySystem.dll
 C:\Users\chudy\Documents\InventorySystem_App\InventorySystem\InventorySystem\InventorySystem\obj\Debug\netstandard2.0\ref\InventorySystem.dll
 C:\Users\chudy\Documents\InventorySystem_App\InventorySystem\InventorySystem\InventorySystem\obj\Debug\netstandard2.0\InventorySystem.pdb
+C:\Users\chudy\Documents\InventorySystem_App\InventorySystem\InventorySystem\InventorySystem\obj\Debug\netstandard2.0\InventorySystem.csprojAssemblyReference.cache
+C:\Users\chudy\Documents\InventorySystem_App\InventorySystem\InventorySystem\InventorySystem\obj\Debug\netstandard2.0\Views\AddBarcodeScannerPage.xaml.g.cs


### PR DESCRIPTION
Instead of only one option inside of AddItemPage, which is to **manually type the barcode**, the page should also have the custom scanner, that will **scan the barcode** and **save it**, so the AddItemPage can **just fetch it**, and **fill the Barcode Entry** instead of manual labor.